### PR TITLE
feat(admin): 新增 admin 导航配置并仅在 dev 显示侧边栏入口

### DIFF
--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -1,108 +1,141 @@
 ---
-import UiIcon from './UiIcon.astro';
-import { ADMIN_NAV_ORNAMENT_DEFAULT } from '../lib/admin-console/theme-shared';
-import { createWithBase } from '../utils/format';
-import { getSidebarHref, getThemeSettings, type SidebarNavId } from '../lib/theme-settings';
+import UiIcon from "./UiIcon.astro";
+import { ADMIN_NAV_ORNAMENT_DEFAULT } from "../lib/admin-console/theme-shared";
+import { createWithBase } from "../utils/format";
+import {
+  getSidebarHref,
+  getThemeSettings,
+  type SidebarNavId,
+} from "../lib/theme-settings";
 
-const {
-  siteTitle = 'Whono',
-  activeNavId
-} = Astro.props as {
+const { siteTitle = "Whono", activeNavId } = Astro.props as {
   siteTitle?: string;
   activeNavId?: SidebarNavId;
 };
 
 const pathname = Astro.url.pathname;
-const base = import.meta.env.BASE_URL ?? '/';
+const isDev = import.meta.env.DEV;
+const base = import.meta.env.BASE_URL ?? "/";
 const withBase = createWithBase(base);
-const homeHref = withBase('/');
+const homeHref = withBase("/");
 const { settings } = getThemeSettings();
 const quote = settings.shell.quote;
 const nav = settings.shell.nav
   .filter((item) => item.visible)
+  .filter((item) => isDev || item.id !== "admin")
   .sort((a, b) => a.order - b.order)
   .map((item) => ({
     id: item.id,
     label: item.label,
     ornament: item.ornament,
-    href: withBase(getSidebarHref(item.id))
+    href: withBase(getSidebarHref(item.id)),
   }));
 const showReaderToggle = settings.ui.readingMode.showEntry;
 const showRssLink = settings.ui.sidebarActions.showRssLink;
 const showThemeToggle = settings.ui.sidebarActions.showThemeToggle;
-const showAdminEntry = settings.ui.sidebarActions.showAdminEntry && settings.site.adminOverview.publicVisible;
+const showAdminEntry =
+  settings.ui.sidebarActions.showAdminEntry &&
+  settings.site.adminOverview.publicVisible;
 ---
 
 <aside class="sidebar">
-  <a class="sidebar__title" href={homeHref} aria-label={`${siteTitle} 首页`}>{siteTitle}</a>
+  <a class="sidebar__title" href={homeHref} aria-label={`${siteTitle} 首页`}
+    >{siteTitle}</a
+  >
 
   <div class="sidebar__quote">
-    {quote.split('\n').map((line) => (
-      <>
-        {line}<br />
-      </>
-    ))}
+    {
+      quote.split("\n").map((line) => (
+        <>
+          {line}
+          <br />
+        </>
+      ))
+    }
   </div>
 
   <ul class="nav">
-    {nav.map((item) => {
-      const isActive = activeNavId
-        ? item.id === activeNavId
-        : pathname === item.href || (item.href !== homeHref && pathname.startsWith(item.href));
-      return (
-        <li>
-          <a href={item.href} aria-current={isActive ? 'page' : undefined}>
-            <span>{item.label}</span>
-            {item.ornament === ADMIN_NAV_ORNAMENT_DEFAULT ? (
-              <span class="dot" aria-hidden="true"></span>
-            ) : item.ornament ? (
-              <span class="nav-ornament" aria-hidden="true">{item.ornament}</span>
-            ) : null}
-          </a>
-        </li>
-      );
-    })}
+    {
+      nav.map((item) => {
+        const isActive = activeNavId
+          ? item.id === activeNavId
+          : pathname === item.href ||
+            (item.href !== homeHref && pathname.startsWith(item.href));
+        return (
+          <li>
+            <a href={item.href} aria-current={isActive ? "page" : undefined}>
+              <span>{item.label}</span>
+              {item.ornament === ADMIN_NAV_ORNAMENT_DEFAULT ? (
+                <span class="dot" aria-hidden="true" />
+              ) : item.ornament ? (
+                <span class="nav-ornament" aria-hidden="true">
+                  {item.ornament}
+                </span>
+              ) : null}
+            </a>
+          </li>
+        );
+      })
+    }
   </ul>
 
   <div class="sidebar-actions">
-    {showReaderToggle ? (
-      <button
-        id="reader-toggle"
-        class="icon-button reader-toggle"
-        type="button"
-        aria-label="阅读模式"
-        aria-pressed="false"
-        title="阅读模式"
-      >
-        <UiIcon name="book-open" class="icon icon-book-open" />
-        <UiIcon name="book-closed" class="icon icon-book-closed" />
-      </button>
-    ) : null}
+    {
+      showReaderToggle ? (
+        <button
+          id="reader-toggle"
+          class="icon-button reader-toggle"
+          type="button"
+          aria-label="阅读模式"
+          aria-pressed="false"
+          title="阅读模式"
+        >
+          <UiIcon name="book-open" class="icon icon-book-open" />
+          <UiIcon name="book-closed" class="icon icon-book-closed" />
+        </button>
+      ) : null
+    }
 
-    {showRssLink ? (
-      <a class="icon-button rss-link" href={withBase('/archive/rss.xml')} aria-label="RSS 订阅" title="RSS 订阅">
-        <UiIcon name="rss" class="icon" />
-      </a>
-    ) : null}
+    {
+      showRssLink ? (
+        <a
+          class="icon-button rss-link"
+          href={withBase("/archive/rss.xml")}
+          aria-label="RSS 订阅"
+          title="RSS 订阅"
+        >
+          <UiIcon name="rss" class="icon" />
+        </a>
+      ) : null
+    }
 
-    {showThemeToggle ? (
-      <button
-        id="theme-toggle"
-        class="icon-button theme-toggle"
-        type="button"
-        aria-label="夜间模式"
-        aria-pressed="false"
-        title="夜间模式"
-      >
-        <UiIcon name="moon" class="icon icon-moon" />
-        <UiIcon name="sun" class="icon icon-sun" />
-      </button>
-    ) : null}
+    {
+      showThemeToggle ? (
+        <button
+          id="theme-toggle"
+          class="icon-button theme-toggle"
+          type="button"
+          aria-label="夜间模式"
+          aria-pressed="false"
+          title="夜间模式"
+        >
+          <UiIcon name="moon" class="icon icon-moon" />
+          <UiIcon name="sun" class="icon icon-sun" />
+        </button>
+      ) : null
+    }
 
-    {showAdminEntry ? (
-      <a class="icon-button admin-entry-link" href={withBase('/admin/')} aria-label="站点概览" title="站点概览">
-        <UiIcon name="monitor-dot" class="icon" />
-      </a>
-    ) : null}
+    {
+      showAdminEntry ? (
+        <a
+          class="icon-button admin-entry-link"
+          href={withBase("/admin/")}
+          aria-label="站点概览"
+          title="站点概览"
+        >
+          <UiIcon name="monitor-dot" class="icon" />
+        </a>
+      ) : null
+    }
   </div>
 </aside>

--- a/src/data/settings/page.json
+++ b/src/data/settings/page.json
@@ -22,5 +22,9 @@
   "about": {
     "title": "关于",
     "subtitle": null
+  },
+  "admin": {
+    "title": "管理后台",
+    "subtitle": null
   }
 }

--- a/src/data/settings/shell.json
+++ b/src/data/settings/shell.json
@@ -36,6 +36,13 @@
       "ornament": "·",
       "visible": true,
       "order": 5
+    },
+    {
+      "id": "admin",
+      "label": "管理后台",
+      "ornament": "·",
+      "visible": true,
+      "order": 6
     }
   ]
 }

--- a/src/lib/admin-console/theme-shared.ts
+++ b/src/lib/admin-console/theme-shared.ts
@@ -24,8 +24,8 @@ export {
   normalizeAdminHeroImageSrc
 };
 
-export const ADMIN_NAV_IDS = ['essay', 'bits', 'memo', 'archive', 'about'] as const satisfies readonly SidebarNavId[];
-export const ADMIN_PAGE_IDS = ['essay', 'archive', 'bits', 'memo', 'about'] as const satisfies readonly PageId[];
+export const ADMIN_NAV_IDS = ['essay', 'bits', 'memo', 'archive', 'about', 'admin'] as const satisfies readonly SidebarNavId[];
+export const ADMIN_PAGE_IDS = ['essay', 'archive', 'bits', 'memo', 'about', 'admin'] as const satisfies readonly PageId[];
 export const ADMIN_SOCIAL_CUSTOM_LIMIT = 8;
 
 export const ADMIN_HERO_PRESETS = ['default', 'none'] as const satisfies readonly HeroPresetId[];
@@ -526,6 +526,10 @@ export const canonicalizeAdminThemeSettings = (
       about: {
         title: normalizeOptionalSingleLine(String(isRecord(page.about) ? page.about.title ?? '' : '')),
         subtitle: normalizeOptionalSingleLine(String(isRecord(page.about) ? page.about.subtitle ?? '' : ''))
+      },
+      admin: {
+        title: normalizeOptionalSingleLine(String(isRecord(page.admin) ? page.admin.title ?? '' : '')),
+        subtitle: normalizeOptionalSingleLine(String(isRecord(page.admin) ? page.admin.subtitle ?? '' : ''))
       }
     },
     ui: {
@@ -605,7 +609,8 @@ export const createAdminWritableThemeSettingsGroups = (
       }
     },
     memo: { ...settings.page.memo },
-    about: { ...settings.page.about }
+    about: { ...settings.page.about },
+    admin: { ...settings.page.admin }
   },
   ui: {
     codeBlock: { ...settings.ui.codeBlock },

--- a/src/lib/theme-settings.ts
+++ b/src/lib/theme-settings.ts
@@ -44,8 +44,8 @@ import {
 
 export type SettingSource = 'new' | 'legacy' | 'default';
 
-export type SidebarNavId = 'essay' | 'bits' | 'memo' | 'archive' | 'about';
-export type PageId = 'essay' | 'archive' | 'bits' | 'memo' | 'about';
+export type SidebarNavId = 'essay' | 'bits' | 'memo' | 'archive' | 'about' | 'admin';
+export type PageId = 'essay' | 'archive' | 'bits' | 'memo' | 'about' | 'admin';
 export type HeroPresetId = 'default' | 'none';
 export type SidebarDividerVariant = 'default' | 'subtle' | 'none';
 export type HomeIntroLinkKey = 'archive' | 'essay' | 'bits' | 'memo' | 'about' | 'tag';
@@ -166,6 +166,7 @@ export interface PageSettings {
   bits: BitsPageSettings;
   memo: MemoPageSettings;
   about: PageHeadingSettings;
+  admin: PageHeadingSettings;
 }
 
 export interface ArticleMetaSettings {
@@ -370,6 +371,7 @@ const LEGACY_ESSAY_SUBTITLE = '随笔与杂记';
 const LEGACY_BITS_TITLE = '絮语';
 const LEGACY_BITS_SUBTITLE = '生活不只是长篇';
 const LEGACY_ABOUT_TITLE = '关于';
+const LEGACY_ADMIN_TITLE = '管理后台';
 const LEGACY_QUOTE = 'A minimal Astro theme\nfor essays, notes, and docs.\nDesigned for reading,\nopen-source.';
 const LEGACY_FOOTER_START_YEAR = 2025;
 const LEGACY_FOOTER_SHOW_CURRENT_YEAR = true;
@@ -392,7 +394,8 @@ const LEGACY_NAV: SidebarNavItem[] = [
   { id: 'bits', label: '絮语', ornament: ADMIN_NAV_ORNAMENT_DEFAULT, visible: true, order: 2 },
   { id: 'memo', label: '小记', ornament: ADMIN_NAV_ORNAMENT_DEFAULT, visible: true, order: 3 },
   { id: 'archive', label: '归档', ornament: ADMIN_NAV_ORNAMENT_DEFAULT, visible: true, order: 4 },
-  { id: 'about', label: '关于', ornament: ADMIN_NAV_ORNAMENT_DEFAULT, visible: true, order: 5 }
+  { id: 'about', label: '关于', ornament: ADMIN_NAV_ORNAMENT_DEFAULT, visible: true, order: 5 },
+  { id: 'admin', label: '管理后台', ornament: ADMIN_NAV_ORNAMENT_DEFAULT, visible: true, order: 6 }
 ];
 const LEGACY_NAV_ORDER = new Map<SidebarNavId, number>(LEGACY_NAV.map((item) => [item.id, item.order]));
 
@@ -487,6 +490,10 @@ const DEFAULT_PAGE: PageSettings = {
   about: {
     title: LEGACY_ABOUT_TITLE,
     subtitle: null
+  },
+  admin: {
+    title: LEGACY_ADMIN_TITLE,
+    subtitle: null
   }
 };
 
@@ -534,7 +541,8 @@ const SIDEBAR_HREFS: Record<SidebarNavId, string> = {
   bits: '/bits/',
   memo: '/memo/',
   archive: '/archive/',
-  about: '/about/'
+  about: '/about/',
+  admin: '/admin/'
 };
 
 let cachedSettings: ThemeSettingsResolved | null = null;
@@ -1110,6 +1118,7 @@ export const getThemeSettings = (): ThemeSettingsResolved => {
   const pageBitsDefaultAuthorJson = isRecord(pageBitsJson?.defaultAuthor) ? pageBitsJson.defaultAuthor : undefined;
   const pageMemoJson = isRecord(pageJson?.memo) ? pageJson.memo : undefined;
   const pageAboutJson = isRecord(pageJson?.about) ? pageJson.about : undefined;
+  const pageAdminJson = isRecord(pageJson?.admin) ? pageJson.admin : undefined;
 
   const title = resolveValue(
     asNonEmptyString(siteJson?.title),
@@ -1304,6 +1313,16 @@ export const getThemeSettings = (): ThemeSettingsResolved => {
     undefined,
     DEFAULT_PAGE.about.subtitle
   );
+  const adminTitle = resolveValue(
+    asNullableString(pageAdminJson?.title),
+    undefined,
+    DEFAULT_PAGE.admin.title
+  );
+  const adminSubtitle = resolveValue<string | null>(
+    asNullableString(pageAdminJson?.subtitle),
+    undefined,
+    DEFAULT_PAGE.admin.subtitle
+  );
 
   const uiCodeBlock = isRecord(uiJson?.codeBlock) ? uiJson.codeBlock : undefined;
   const uiReadingMode = isRecord(uiJson?.readingMode) ? uiJson.readingMode : undefined;
@@ -1451,6 +1470,10 @@ export const getThemeSettings = (): ThemeSettingsResolved => {
         about: {
           title: aboutTitle.value,
           subtitle: aboutSubtitle.value
+        },
+        admin: {
+          title: adminTitle.value,
+          subtitle: adminSubtitle.value
         }
       },
       ui: {
@@ -1608,7 +1631,8 @@ const buildEditableThemeSettingsSnapshot = (
         }
       },
       memo: { ...resolved.settings.page.memo },
-      about: { ...resolved.settings.page.about }
+      about: { ...resolved.settings.page.about },
+      admin: { ...resolved.settings.page.admin }
     },
     ui: {
       codeBlock: { ...resolved.settings.ui.codeBlock },

--- a/src/pages/admin/theme/index.astro
+++ b/src/pages/admin/theme/index.astro
@@ -51,7 +51,8 @@ const loadThemeDevState = async () => {
     bits: '絮语',
     memo: '小记',
     archive: '归档',
-    about: '关于'
+    about: '关于',
+    admin: '管理后台'
   } as const;
   const footerStartYearMin = ADMIN_FOOTER_START_YEAR_MIN;
   const footerStartYearMax = getAdminFooterStartYearMax();


### PR DESCRIPTION
在DEV预览模式侧边栏添加“管理后台”入口，方便dev状态进入后台

| preview | dev |
|-----|-----|
| <img width="1825" height="1011" alt="0fd16198-d175-4c37-a0b0-bc4b2bbc13fd" src="https://github.com/user-attachments/assets/33c8089b-e4db-40ba-992f-c5fe6abfe736" /> | <img width="2133" height="1204" alt="2f58b3be-30a3-4ac9-b62b-54bd33a17a30" src="https://github.com/user-attachments/assets/cf32f062-0c84-4852-8090-c5b42490df8c" /> |