### PR TITLE
fix(ui): 防止长标题时 badge 被挤压换行并保持单行展示

### DIFF
--- a/src/components/EssayCard.astro
+++ b/src/components/EssayCard.astro
@@ -42,17 +42,12 @@ const shouldShowMetaLine = articleMetaSettings.showDate || (articleMetaSettings.
     <div class="meta-line meta-line--items">
       {articleMetaSettings.showDate ? (
         <span class="meta-line__item">
-          {articleMetaSettings.dateLabel
-            ? `${articleMetaSettings.dateLabel}`
-            : ""}
-          {formatISODateUtc(date)}
+          {articleMetaSettings.dateLabel ? `${articleMetaSettings.dateLabel}` : ''}{formatISODateUtc(date)}
         </span>
       ) : null}
       {articleMetaSettings.showTags && visibleTags.length ? (
         <span class="meta-line__item meta-line__item--tags">
-          {visibleTags.map((tag) => (
-            <span class="tag">#{tag}</span>
-          ))}
+          {visibleTags.map((tag) => (<span class="tag">#{tag}</span>))}
         </span>
       ) : null}
     </div>

--- a/src/components/EssayCard.astro
+++ b/src/components/EssayCard.astro
@@ -1,6 +1,6 @@
 ---
-import { formatISODateUtc } from "../utils/format";
-import type { ArticleMetaSettings } from "../lib/theme-settings";
+import { formatISODateUtc } from '../utils/format';
+import type { ArticleMetaSettings } from '../lib/theme-settings';
 
 const {
   href,
@@ -8,8 +8,8 @@ const {
   excerpt,
   date,
   visibleTags = [],
-  badge = "随笔",
-  slug = "",
+  badge = '随笔',
+  slug = '',
   articleMetaSettings,
 } = Astro.props as {
   href: string;
@@ -21,7 +21,7 @@ const {
   slug?: string;
   articleMetaSettings: ArticleMetaSettings;
 };
-const displayBadge = badge.trim() ? badge : "随笔";
+const displayBadge = badge.trim() ? badge : '随笔';
 const shouldShowMetaLine =
   articleMetaSettings.showDate ||
   (articleMetaSettings.showTags && visibleTags.length > 0);

--- a/src/components/EssayCard.astro
+++ b/src/components/EssayCard.astro
@@ -10,7 +10,7 @@ const {
   visibleTags = [],
   badge = '随笔',
   slug = '',
-  articleMetaSettings,
+  articleMetaSettings
 } = Astro.props as {
   href: string;
   title: string;
@@ -22,9 +22,7 @@ const {
   articleMetaSettings: ArticleMetaSettings;
 };
 const displayBadge = badge.trim() ? badge : '随笔';
-const shouldShowMetaLine =
-  articleMetaSettings.showDate ||
-  (articleMetaSettings.showTags && visibleTags.length > 0);
+const shouldShowMetaLine = articleMetaSettings.showDate || (articleMetaSettings.showTags && visibleTags.length > 0);
 ---
 
 <a
@@ -40,25 +38,23 @@ const shouldShowMetaLine =
     </div>
   </div>
   {excerpt ? <p class="list-item__excerpt">{excerpt}</p> : null}
-  {
-    shouldShowMetaLine ? (
-      <div class="meta-line meta-line--items">
-        {articleMetaSettings.showDate ? (
-          <span class="meta-line__item">
-            {articleMetaSettings.dateLabel
-              ? `${articleMetaSettings.dateLabel}`
-              : ""}
-            {formatISODateUtc(date)}
-          </span>
-        ) : null}
-        {articleMetaSettings.showTags && visibleTags.length ? (
-          <span class="meta-line__item meta-line__item--tags">
-            {visibleTags.map((tag) => (
-              <span class="tag">#{tag}</span>
-            ))}
-          </span>
-        ) : null}
-      </div>
-    ) : null
-  }
+  {shouldShowMetaLine ? (
+    <div class="meta-line meta-line--items">
+      {articleMetaSettings.showDate ? (
+        <span class="meta-line__item">
+          {articleMetaSettings.dateLabel
+            ? `${articleMetaSettings.dateLabel}`
+            : ""}
+          {formatISODateUtc(date)}
+        </span>
+      ) : null}
+      {articleMetaSettings.showTags && visibleTags.length ? (
+        <span class="meta-line__item meta-line__item--tags">
+          {visibleTags.map((tag) => (
+            <span class="tag">#{tag}</span>
+          ))}
+        </span>
+      ) : null}
+    </div>
+  ) : null}
 </a>

--- a/src/components/EssayCard.astro
+++ b/src/components/EssayCard.astro
@@ -1,6 +1,6 @@
 ---
-import { formatISODateUtc } from '../utils/format';
-import type { ArticleMetaSettings } from '../lib/theme-settings';
+import { formatISODateUtc } from "../utils/format";
+import type { ArticleMetaSettings } from "../lib/theme-settings";
 
 const {
   href,
@@ -8,9 +8,9 @@ const {
   excerpt,
   date,
   visibleTags = [],
-  badge = '随笔',
-  slug = '',
-  articleMetaSettings
+  badge = "随笔",
+  slug = "",
+  articleMetaSettings,
 } = Astro.props as {
   href: string;
   title: string;
@@ -21,8 +21,10 @@ const {
   slug?: string;
   articleMetaSettings: ArticleMetaSettings;
 };
-const displayBadge = badge.trim() ? badge : '随笔';
-const shouldShowMetaLine = articleMetaSettings.showDate || (articleMetaSettings.showTags && visibleTags.length > 0);
+const displayBadge = badge.trim() ? badge : "随笔";
+const shouldShowMetaLine =
+  articleMetaSettings.showDate ||
+  (articleMetaSettings.showTags && visibleTags.length > 0);
 ---
 
 <a
@@ -32,24 +34,31 @@ const shouldShowMetaLine = articleMetaSettings.showDate || (articleMetaSettings.
   data-slug={slug || undefined}
 >
   <div class="list-item__row">
-    <div style="display:flex; align-items:center; gap:10px;">
+    <div style="display:flex; align-items:center; gap:10px; min-width:0;">
       <span class="badge">{displayBadge}</span>
-      <h2 class="list-item__title" style="margin:0;">{title}</h2>
+      <h2 class="list-item__title" style="margin:0; min-width:0;">{title}</h2>
     </div>
   </div>
   {excerpt ? <p class="list-item__excerpt">{excerpt}</p> : null}
-  {shouldShowMetaLine ? (
-    <div class="meta-line meta-line--items">
-      {articleMetaSettings.showDate ? (
-        <span class="meta-line__item">
-          {articleMetaSettings.dateLabel ? `${articleMetaSettings.dateLabel}` : ''}{formatISODateUtc(date)}
-        </span>
-      ) : null}
-      {articleMetaSettings.showTags && visibleTags.length ? (
-        <span class="meta-line__item meta-line__item--tags">
-          {visibleTags.map((tag) => <span class="tag">#{tag}</span>)}
-        </span>
-      ) : null}
-    </div>
-  ) : null}
+  {
+    shouldShowMetaLine ? (
+      <div class="meta-line meta-line--items">
+        {articleMetaSettings.showDate ? (
+          <span class="meta-line__item">
+            {articleMetaSettings.dateLabel
+              ? `${articleMetaSettings.dateLabel}`
+              : ""}
+            {formatISODateUtc(date)}
+          </span>
+        ) : null}
+        {articleMetaSettings.showTags && visibleTags.length ? (
+          <span class="meta-line__item meta-line__item--tags">
+            {visibleTags.map((tag) => (
+              <span class="tag">#{tag}</span>
+            ))}
+          </span>
+        ) : null}
+      </div>
+    ) : null
+  }
 </a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,34 +5,18 @@ import EntryListItem from '../components/EntryListItem.astro';
 import '../styles/home.css';
 import {
   ADMIN_HOME_INTRO_LINK_DEFAULT,
-  getAdminHomeIntroLinkOption,
+  getAdminHomeIntroLinkOption
 } from '../lib/admin-console/theme-shared';
-import {
-  getEssayDerivedText,
-  getEssaySlug,
-  getVisibleEssays,
-} from '../lib/content';
-import {
-  getThemeSettings,
-  getVisibleArticleMetaTags,
-} from '../lib/theme-settings';
+import { getEssayDerivedText, getEssaySlug, getVisibleEssays } from '../lib/content';
+import { getThemeSettings, getVisibleArticleMetaTags } from '../lib/theme-settings';
 import { createWithBase } from '../utils/format';
 
 const base = import.meta.env.BASE_URL ?? '/';
 const withBase = createWithBase(base);
 const {
   settings: {
-    home: {
-      introLead,
-      introMore,
-      introMoreLinks,
-      showIntroLead,
-      showIntroMore,
-      heroPresetId,
-      heroImageSrc,
-      heroImageAlt,
-    },
-    ui: { articleMeta },
+    home: { introLead, introMore, introMoreLinks, showIntroLead, showIntroMore, heroPresetId, heroImageSrc, heroImageAlt },
+    ui: { articleMeta }
   },
 } = getThemeSettings();
 const shouldShowHero = heroPresetId !== 'none';
@@ -41,13 +25,13 @@ const homeBodyClass = [
   'home',
   !shouldShowHero ? 'home--no-hero' : null,
   !shouldShowIntro ? 'home--no-intro' : null,
-  !shouldShowHero && !shouldShowIntro ? 'home--compact-start' : null,
+  !shouldShowHero && !shouldShowIntro ? 'home--compact-start' : null
 ]
   .filter(Boolean)
   .join(' ');
-const resolvedIntroMoreLinks = (
-  introMoreLinks.length ? introMoreLinks : [...ADMIN_HOME_INTRO_LINK_DEFAULT]
-).map((linkKey) => getAdminHomeIntroLinkOption(linkKey));
+const resolvedIntroMoreLinks = (introMoreLinks.length ? introMoreLinks : [...ADMIN_HOME_INTRO_LINK_DEFAULT]).map(
+  (linkKey) => getAdminHomeIntroLinkOption(linkKey)
+);
 
 const latest = (await getVisibleEssays()).slice(0, 12);
 
@@ -64,37 +48,37 @@ const HOME_HEAD_CRITICAL_FONT_FACES = [
     family: 'LXGW WenKai Lite',
     fileName: 'lxgw-wenkai-lite-latin.woff2',
     weight: 400,
-    unicodeRange: 'U+0000-00FF, U+2000-206F, U+3000-303F, U+FF00-FFEF',
+    unicodeRange: 'U+0000-00FF, U+2000-206F, U+3000-303F, U+FF00-FFEF'
   },
   {
     family: 'LXGW WenKai Lite',
     fileName: 'lxgw-wenkai-lite-cjk-common.woff2',
     weight: 400,
-    unicodeRange: 'U+4E00-9FFF',
+    unicodeRange: 'U+4E00-9FFF'
   },
   {
     family: 'Noto Serif SC',
     fileName: 'noto-serif-sc-400-latin.woff2',
     weight: 400,
-    unicodeRange: 'U+0000-00FF, U+2000-206F, U+3000-303F, U+FF00-FFEF',
+    unicodeRange: 'U+0000-00FF, U+2000-206F, U+3000-303F, U+FF00-FFEF'
   },
   {
     family: 'Noto Serif SC',
     fileName: 'noto-serif-sc-400-cjk-common.woff2',
     weight: 400,
-    unicodeRange: 'U+4E00-9FFF',
+    unicodeRange: 'U+4E00-9FFF'
   },
   {
     family: 'Noto Serif SC',
     fileName: 'noto-serif-sc-600-latin.woff2',
     weight: 600,
-    unicodeRange: 'U+0000-00FF, U+2000-206F, U+3000-303F, U+FF00-FFEF',
+    unicodeRange: 'U+0000-00FF, U+2000-206F, U+3000-303F, U+FF00-FFEF'
   },
   {
     family: 'Noto Serif SC',
     fileName: 'noto-serif-sc-600-cjk-common.woff2',
     weight: 600,
-    unicodeRange: 'U+4E00-9FFF',
+    unicodeRange: 'U+4E00-9FFF'
   },
 ] as const satisfies readonly HomeHeadCriticalFontFace[];
 
@@ -102,10 +86,10 @@ const renderHomeHeadCriticalFontFace = ({
   family,
   fileName,
   weight,
-  unicodeRange,
+  unicodeRange
 }: HomeHeadCriticalFontFace): string => String.raw`@font-face {
-  font-family: '${family}';
-  src: url('${withBase(`/fonts/${fileName}`)}') format('woff2');
+  font-family: "${family}";
+  src: url("${withBase(`/fonts/${fileName}`)}") format('woff2');
   font-weight: ${weight};
   font-style: normal;
   font-display: swap;
@@ -113,9 +97,7 @@ const renderHomeHeadCriticalFontFace = ({
 }`;
 
 const homeHeadCriticalCss = [
-  HOME_HEAD_CRITICAL_FONT_FACES.map(renderHomeHeadCriticalFontFace).join(
-    '\n\n',
-  ),
+  HOME_HEAD_CRITICAL_FONT_FACES.map(renderHomeHeadCriticalFontFace).join('\n\n'),
   String.raw`
 
 :root {
@@ -135,7 +117,7 @@ const homeHeadCriticalCss = [
   --card-pad: 12px 14px;
 }
 
-:root[data-theme='dark'] {
+:root[data-theme="dark"] {
   color-scheme: dark;
   --bg: #1a1a1a;
   --text: #e5e5e5;
@@ -157,7 +139,7 @@ body {
   padding: 0;
   background: var(--bg);
   color: var(--text);
-  font-family: 'Noto Serif SC', ui-serif, Georgia, 'Times New Roman', 'Songti SC', serif;
+  font-family: "Noto Serif SC", ui-serif, Georgia, "Times New Roman", "Songti SC", serif;
   line-height: 1.75;
   font-size: 16px;
 }
@@ -259,7 +241,7 @@ a {
   font-size: 16px;
 }
 
-.nav a[aria-current='page'] {
+.nav a[aria-current="page"] {
   text-decoration: underline;
   text-underline-offset: 5px;
 }
@@ -281,7 +263,7 @@ a {
   opacity: 0.55;
   font-size: 14px;
   line-height: 1;
-  font-family: 'LXGW WenKai Lite', 'Kaiti SC', 'STKaiti', serif;
+  font-family: "LXGW WenKai Lite", "Kaiti SC", "STKaiti", serif;
 }
 
 .sidebar-actions {
@@ -315,11 +297,11 @@ a {
   display: none;
 }
 
-:root[data-theme='dark'] .theme-toggle .icon-sun {
+:root[data-theme="dark"] .theme-toggle .icon-sun {
   display: block;
 }
 
-:root[data-theme='dark'] .theme-toggle .icon-moon {
+:root[data-theme="dark"] .theme-toggle .icon-moon {
   display: none;
 }
 
@@ -327,11 +309,11 @@ a {
   display: none;
 }
 
-body[data-reading='immersive'] .reader-toggle .icon-book-closed {
+body[data-reading="immersive"] .reader-toggle .icon-book-closed {
   display: block;
 }
 
-body[data-reading='immersive'] .reader-toggle .icon-book-open {
+body[data-reading="immersive"] .reader-toggle .icon-book-open {
   display: none;
 }
 
@@ -367,7 +349,7 @@ body[data-reading='immersive'] .reader-toggle .icon-book-open {
 }
 
 .section-title::after {
-  content: '';
+  content: "";
   display: block;
   width: 32px;
   height: 1px;
@@ -424,7 +406,7 @@ body[data-reading='immersive'] .reader-toggle .icon-book-open {
   -webkit-line-clamp: 3;
   line-clamp: 3;
   overflow: hidden;
-  font-family: 'LXGW WenKai Lite', 'Kaiti SC', 'STKaiti', serif;
+  font-family: "LXGW WenKai Lite", "Kaiti SC", "STKaiti", serif;
 }
 
 .meta-line {
@@ -450,7 +432,7 @@ body[data-reading='immersive'] .reader-toggle .icon-book-open {
 }
 
 .meta-line__item + .meta-line__item::before {
-  content: '·';
+  content: "·";
   margin: 0 0.45em;
   color: var(--faint);
 }
@@ -489,7 +471,7 @@ body[data-reading='immersive'] .reader-toggle .icon-book-open {
     --header-gap: 4px;
   }
 
-  :root[data-theme='dark'] {
+  :root[data-theme="dark"] {
     color-scheme: dark;
     --bg: #1a1a1a;
     --text: #e5e5e5;
@@ -550,7 +532,7 @@ body[data-reading='immersive'] .reader-toggle .icon-book-open {
     transform-origin: left center;
   }
 
-  .nav a[aria-current='page'] {
+  .nav a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 6px;
     text-decoration-thickness: 2px;
@@ -636,7 +618,7 @@ body[data-reading='immersive'] .reader-toggle .icon-book-open {
       calc(36px + env(safe-area-inset-bottom)) calc(var(--pad-x) + env(safe-area-inset-left));
   }
 }
-`,
+`
 ].join('\n\n');
 ---
 
@@ -660,8 +642,8 @@ body[data-reading='immersive'] .reader-toggle .icon-book-open {
             {introMore}
             {resolvedIntroMoreLinks.map((link, index) => (
               <>
-                {" "}
-                {index > 0 && <>或 </>}
+                {' '}
+                {index > 0 && <>或{' '}</>}
                 {index === resolvedIntroMoreLinks.length - 1 ? (
                   <span class="intro__link-tail">
                     <a href={withBase(link.href)}>{link.label}</a>
@@ -681,22 +663,20 @@ body[data-reading='immersive'] .reader-toggle .icon-book-open {
   <h2 class="section-title section-title--index">索引</h2>
 
   <div class="list">
-    {
-      latest.map((entry) => {
-        const slug = getEssaySlug(entry);
-        const href = withBase(`/archive/${slug}/`);
-        const visibleTags = getVisibleArticleMetaTags(entry.data.tags, "home");
-        return (
-          <EntryListItem
-            href={href}
-            title={entry.data.title}
-            date={entry.data.date}
-            visibleTags={visibleTags}
-            articleMetaSettings={articleMeta}
-            excerpt={getEssayDerivedText(entry).excerpt}
-          />
-        );
-      })
-    }
+    {latest.map((entry) => {
+      const slug = getEssaySlug(entry);
+      const href = withBase(`/archive/${slug}/`);
+      const visibleTags = getVisibleArticleMetaTags(entry.data.tags, "home");
+      return (
+        <EntryListItem
+          href={href}
+          title={entry.data.title}
+          date={entry.data.date}
+          visibleTags={visibleTags}
+          articleMetaSettings={articleMeta}
+          excerpt={getEssayDerivedText(entry).excerpt}
+        />
+      );
+    })}
   </div>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,24 +1,24 @@
 ---
-import BaseLayout from "../layouts/BaseLayout.astro";
-import HeroImage from "../components/HeroImage.astro";
-import EntryListItem from "../components/EntryListItem.astro";
-import "../styles/home.css";
+import BaseLayout from '../layouts/BaseLayout.astro';
+import HeroImage from '../components/HeroImage.astro';
+import EntryListItem from '../components/EntryListItem.astro';
+import '../styles/home.css';
 import {
   ADMIN_HOME_INTRO_LINK_DEFAULT,
   getAdminHomeIntroLinkOption,
-} from "../lib/admin-console/theme-shared";
+} from '../lib/admin-console/theme-shared';
 import {
   getEssayDerivedText,
   getEssaySlug,
   getVisibleEssays,
-} from "../lib/content";
+} from '../lib/content';
 import {
   getThemeSettings,
   getVisibleArticleMetaTags,
-} from "../lib/theme-settings";
-import { createWithBase } from "../utils/format";
+} from '../lib/theme-settings';
+import { createWithBase } from '../utils/format';
 
-const base = import.meta.env.BASE_URL ?? "/";
+const base = import.meta.env.BASE_URL ?? '/';
 const withBase = createWithBase(base);
 const {
   settings: {
@@ -35,16 +35,16 @@ const {
     ui: { articleMeta },
   },
 } = getThemeSettings();
-const shouldShowHero = heroPresetId !== "none";
+const shouldShowHero = heroPresetId !== 'none';
 const shouldShowIntro = showIntroLead || showIntroMore;
 const homeBodyClass = [
-  "home",
-  !shouldShowHero ? "home--no-hero" : null,
-  !shouldShowIntro ? "home--no-intro" : null,
-  !shouldShowHero && !shouldShowIntro ? "home--compact-start" : null,
+  'home',
+  !shouldShowHero ? 'home--no-hero' : null,
+  !shouldShowIntro ? 'home--no-intro' : null,
+  !shouldShowHero && !shouldShowIntro ? 'home--compact-start' : null,
 ]
   .filter(Boolean)
-  .join(" ");
+  .join(' ');
 const resolvedIntroMoreLinks = (
   introMoreLinks.length ? introMoreLinks : [...ADMIN_HOME_INTRO_LINK_DEFAULT]
 ).map((linkKey) => getAdminHomeIntroLinkOption(linkKey));
@@ -52,7 +52,7 @@ const resolvedIntroMoreLinks = (
 const latest = (await getVisibleEssays()).slice(0, 12);
 
 type HomeHeadCriticalFontFace = {
-  family: "LXGW WenKai Lite" | "Noto Serif SC";
+  family: 'LXGW WenKai Lite' | 'Noto Serif SC';
   fileName: string;
   weight: 400 | 600;
   unicodeRange: string;
@@ -61,40 +61,40 @@ type HomeHeadCriticalFontFace = {
 // Keep this subset aligned with the faces the home shell actually uses above the fold.
 const HOME_HEAD_CRITICAL_FONT_FACES = [
   {
-    family: "LXGW WenKai Lite",
-    fileName: "lxgw-wenkai-lite-latin.woff2",
+    family: 'LXGW WenKai Lite',
+    fileName: 'lxgw-wenkai-lite-latin.woff2',
     weight: 400,
-    unicodeRange: "U+0000-00FF, U+2000-206F, U+3000-303F, U+FF00-FFEF",
+    unicodeRange: 'U+0000-00FF, U+2000-206F, U+3000-303F, U+FF00-FFEF',
   },
   {
-    family: "LXGW WenKai Lite",
-    fileName: "lxgw-wenkai-lite-cjk-common.woff2",
+    family: 'LXGW WenKai Lite',
+    fileName: 'lxgw-wenkai-lite-cjk-common.woff2',
     weight: 400,
-    unicodeRange: "U+4E00-9FFF",
+    unicodeRange: 'U+4E00-9FFF',
   },
   {
-    family: "Noto Serif SC",
-    fileName: "noto-serif-sc-400-latin.woff2",
+    family: 'Noto Serif SC',
+    fileName: 'noto-serif-sc-400-latin.woff2',
     weight: 400,
-    unicodeRange: "U+0000-00FF, U+2000-206F, U+3000-303F, U+FF00-FFEF",
+    unicodeRange: 'U+0000-00FF, U+2000-206F, U+3000-303F, U+FF00-FFEF',
   },
   {
-    family: "Noto Serif SC",
-    fileName: "noto-serif-sc-400-cjk-common.woff2",
+    family: 'Noto Serif SC',
+    fileName: 'noto-serif-sc-400-cjk-common.woff2',
     weight: 400,
-    unicodeRange: "U+4E00-9FFF",
+    unicodeRange: 'U+4E00-9FFF',
   },
   {
-    family: "Noto Serif SC",
-    fileName: "noto-serif-sc-600-latin.woff2",
+    family: 'Noto Serif SC',
+    fileName: 'noto-serif-sc-600-latin.woff2',
     weight: 600,
-    unicodeRange: "U+0000-00FF, U+2000-206F, U+3000-303F, U+FF00-FFEF",
+    unicodeRange: 'U+0000-00FF, U+2000-206F, U+3000-303F, U+FF00-FFEF',
   },
   {
-    family: "Noto Serif SC",
-    fileName: "noto-serif-sc-600-cjk-common.woff2",
+    family: 'Noto Serif SC',
+    fileName: 'noto-serif-sc-600-cjk-common.woff2',
     weight: 600,
-    unicodeRange: "U+4E00-9FFF",
+    unicodeRange: 'U+4E00-9FFF',
   },
 ] as const satisfies readonly HomeHeadCriticalFontFace[];
 
@@ -104,8 +104,8 @@ const renderHomeHeadCriticalFontFace = ({
   weight,
   unicodeRange,
 }: HomeHeadCriticalFontFace): string => String.raw`@font-face {
-  font-family: "${family}";
-  src: url("${withBase(`/fonts/${fileName}`)}") format("woff2");
+  font-family: '${family}';
+  src: url('${withBase(`/fonts/${fileName}`)}') format('woff2');
   font-weight: ${weight};
   font-style: normal;
   font-display: swap;
@@ -114,7 +114,7 @@ const renderHomeHeadCriticalFontFace = ({
 
 const homeHeadCriticalCss = [
   HOME_HEAD_CRITICAL_FONT_FACES.map(renderHomeHeadCriticalFontFace).join(
-    "\n\n",
+    '\n\n',
   ),
   String.raw`
 
@@ -135,7 +135,7 @@ const homeHeadCriticalCss = [
   --card-pad: 12px 14px;
 }
 
-:root[data-theme="dark"] {
+:root[data-theme='dark'] {
   color-scheme: dark;
   --bg: #1a1a1a;
   --text: #e5e5e5;
@@ -157,7 +157,7 @@ body {
   padding: 0;
   background: var(--bg);
   color: var(--text);
-  font-family: "Noto Serif SC", ui-serif, Georgia, "Times New Roman", "Songti SC", serif;
+  font-family: 'Noto Serif SC', ui-serif, Georgia, 'Times New Roman', 'Songti SC', serif;
   line-height: 1.75;
   font-size: 16px;
 }
@@ -259,7 +259,7 @@ a {
   font-size: 16px;
 }
 
-.nav a[aria-current="page"] {
+.nav a[aria-current='page'] {
   text-decoration: underline;
   text-underline-offset: 5px;
 }
@@ -281,7 +281,7 @@ a {
   opacity: 0.55;
   font-size: 14px;
   line-height: 1;
-  font-family: "LXGW WenKai Lite", "Kaiti SC", "STKaiti", serif;
+  font-family: 'LXGW WenKai Lite', 'Kaiti SC', 'STKaiti', serif;
 }
 
 .sidebar-actions {
@@ -315,11 +315,11 @@ a {
   display: none;
 }
 
-:root[data-theme="dark"] .theme-toggle .icon-sun {
+:root[data-theme='dark'] .theme-toggle .icon-sun {
   display: block;
 }
 
-:root[data-theme="dark"] .theme-toggle .icon-moon {
+:root[data-theme='dark'] .theme-toggle .icon-moon {
   display: none;
 }
 
@@ -327,11 +327,11 @@ a {
   display: none;
 }
 
-body[data-reading="immersive"] .reader-toggle .icon-book-closed {
+body[data-reading='immersive'] .reader-toggle .icon-book-closed {
   display: block;
 }
 
-body[data-reading="immersive"] .reader-toggle .icon-book-open {
+body[data-reading='immersive'] .reader-toggle .icon-book-open {
   display: none;
 }
 
@@ -367,7 +367,7 @@ body[data-reading="immersive"] .reader-toggle .icon-book-open {
 }
 
 .section-title::after {
-  content: "";
+  content: '';
   display: block;
   width: 32px;
   height: 1px;
@@ -424,7 +424,7 @@ body[data-reading="immersive"] .reader-toggle .icon-book-open {
   -webkit-line-clamp: 3;
   line-clamp: 3;
   overflow: hidden;
-  font-family: "LXGW WenKai Lite", "Kaiti SC", "STKaiti", serif;
+  font-family: 'LXGW WenKai Lite', 'Kaiti SC', 'STKaiti', serif;
 }
 
 .meta-line {
@@ -450,7 +450,7 @@ body[data-reading="immersive"] .reader-toggle .icon-book-open {
 }
 
 .meta-line__item + .meta-line__item::before {
-  content: "·";
+  content: '·';
   margin: 0 0.45em;
   color: var(--faint);
 }
@@ -489,7 +489,7 @@ body[data-reading="immersive"] .reader-toggle .icon-book-open {
     --header-gap: 4px;
   }
 
-  :root[data-theme="dark"] {
+  :root[data-theme='dark'] {
     color-scheme: dark;
     --bg: #1a1a1a;
     --text: #e5e5e5;
@@ -550,7 +550,7 @@ body[data-reading="immersive"] .reader-toggle .icon-book-open {
     transform-origin: left center;
   }
 
-  .nav a[aria-current="page"] {
+  .nav a[aria-current='page'] {
     text-decoration: underline;
     text-underline-offset: 6px;
     text-decoration-thickness: 2px;
@@ -637,7 +637,7 @@ body[data-reading="immersive"] .reader-toggle .icon-book-open {
   }
 }
 `,
-].join("\n\n");
+].join('\n\n');
 ---
 
 <BaseLayout bodyClass={homeBodyClass} deferGlobalStyles={true}>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,7 +17,7 @@ const {
   settings: {
     home: { introLead, introMore, introMoreLinks, showIntroLead, showIntroMore, heroPresetId, heroImageSrc, heroImageAlt },
     ui: { articleMeta }
-  },
+  }
 } = getThemeSettings();
 const shouldShowHero = heroPresetId !== 'none';
 const shouldShowIntro = showIntroLead || showIntroMore;
@@ -79,7 +79,7 @@ const HOME_HEAD_CRITICAL_FONT_FACES = [
     fileName: 'noto-serif-sc-600-cjk-common.woff2',
     weight: 600,
     unicodeRange: 'U+4E00-9FFF'
-  },
+  }
 ] as const satisfies readonly HomeHeadCriticalFontFace[];
 
 const renderHomeHeadCriticalFontFace = ({
@@ -89,7 +89,7 @@ const renderHomeHeadCriticalFontFace = ({
   unicodeRange
 }: HomeHeadCriticalFontFace): string => String.raw`@font-face {
   font-family: "${family}";
-  src: url("${withBase(`/fonts/${fileName}`)}") format('woff2');
+  src: url("${withBase(`/fonts/${fileName}`)}") format("woff2");
   font-weight: ${weight};
   font-style: normal;
   font-display: swap;
@@ -666,7 +666,7 @@ body[data-reading="immersive"] .reader-toggle .icon-book-open {
     {latest.map((entry) => {
       const slug = getEssaySlug(entry);
       const href = withBase(`/archive/${slug}/`);
-      const visibleTags = getVisibleArticleMetaTags(entry.data.tags, "home");
+      const visibleTags = getVisibleArticleMetaTags(entry.data.tags, 'home');
       return (
         <EntryListItem
           href={href}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,42 +1,58 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
-import HeroImage from '../components/HeroImage.astro';
-import EntryListItem from '../components/EntryListItem.astro';
-import '../styles/home.css';
+import BaseLayout from "../layouts/BaseLayout.astro";
+import HeroImage from "../components/HeroImage.astro";
+import EntryListItem from "../components/EntryListItem.astro";
+import "../styles/home.css";
 import {
   ADMIN_HOME_INTRO_LINK_DEFAULT,
-  getAdminHomeIntroLinkOption
-} from '../lib/admin-console/theme-shared';
-import { getEssayDerivedText, getEssaySlug, getVisibleEssays } from '../lib/content';
-import { getThemeSettings, getVisibleArticleMetaTags } from '../lib/theme-settings';
-import { createWithBase } from '../utils/format';
+  getAdminHomeIntroLinkOption,
+} from "../lib/admin-console/theme-shared";
+import {
+  getEssayDerivedText,
+  getEssaySlug,
+  getVisibleEssays,
+} from "../lib/content";
+import {
+  getThemeSettings,
+  getVisibleArticleMetaTags,
+} from "../lib/theme-settings";
+import { createWithBase } from "../utils/format";
 
-const base = import.meta.env.BASE_URL ?? '/';
+const base = import.meta.env.BASE_URL ?? "/";
 const withBase = createWithBase(base);
 const {
   settings: {
-    home: { introLead, introMore, introMoreLinks, showIntroLead, showIntroMore, heroPresetId, heroImageSrc, heroImageAlt },
-    ui: { articleMeta }
-  }
+    home: {
+      introLead,
+      introMore,
+      introMoreLinks,
+      showIntroLead,
+      showIntroMore,
+      heroPresetId,
+      heroImageSrc,
+      heroImageAlt,
+    },
+    ui: { articleMeta },
+  },
 } = getThemeSettings();
-const shouldShowHero = heroPresetId !== 'none';
+const shouldShowHero = heroPresetId !== "none";
 const shouldShowIntro = showIntroLead || showIntroMore;
 const homeBodyClass = [
-  'home',
-  !shouldShowHero ? 'home--no-hero' : null,
-  !shouldShowIntro ? 'home--no-intro' : null,
-  !shouldShowHero && !shouldShowIntro ? 'home--compact-start' : null
+  "home",
+  !shouldShowHero ? "home--no-hero" : null,
+  !shouldShowIntro ? "home--no-intro" : null,
+  !shouldShowHero && !shouldShowIntro ? "home--compact-start" : null,
 ]
   .filter(Boolean)
-  .join(' ');
-const resolvedIntroMoreLinks = (introMoreLinks.length ? introMoreLinks : [...ADMIN_HOME_INTRO_LINK_DEFAULT]).map(
-  (linkKey) => getAdminHomeIntroLinkOption(linkKey)
-);
+  .join(" ");
+const resolvedIntroMoreLinks = (
+  introMoreLinks.length ? introMoreLinks : [...ADMIN_HOME_INTRO_LINK_DEFAULT]
+).map((linkKey) => getAdminHomeIntroLinkOption(linkKey));
 
 const latest = (await getVisibleEssays()).slice(0, 12);
 
 type HomeHeadCriticalFontFace = {
-  family: 'LXGW WenKai Lite' | 'Noto Serif SC';
+  family: "LXGW WenKai Lite" | "Noto Serif SC";
   fileName: string;
   weight: 400 | 600;
   unicodeRange: string;
@@ -45,48 +61,48 @@ type HomeHeadCriticalFontFace = {
 // Keep this subset aligned with the faces the home shell actually uses above the fold.
 const HOME_HEAD_CRITICAL_FONT_FACES = [
   {
-    family: 'LXGW WenKai Lite',
-    fileName: 'lxgw-wenkai-lite-latin.woff2',
+    family: "LXGW WenKai Lite",
+    fileName: "lxgw-wenkai-lite-latin.woff2",
     weight: 400,
-    unicodeRange: 'U+0000-00FF, U+2000-206F, U+3000-303F, U+FF00-FFEF'
+    unicodeRange: "U+0000-00FF, U+2000-206F, U+3000-303F, U+FF00-FFEF",
   },
   {
-    family: 'LXGW WenKai Lite',
-    fileName: 'lxgw-wenkai-lite-cjk-common.woff2',
+    family: "LXGW WenKai Lite",
+    fileName: "lxgw-wenkai-lite-cjk-common.woff2",
     weight: 400,
-    unicodeRange: 'U+4E00-9FFF'
+    unicodeRange: "U+4E00-9FFF",
   },
   {
-    family: 'Noto Serif SC',
-    fileName: 'noto-serif-sc-400-latin.woff2',
+    family: "Noto Serif SC",
+    fileName: "noto-serif-sc-400-latin.woff2",
     weight: 400,
-    unicodeRange: 'U+0000-00FF, U+2000-206F, U+3000-303F, U+FF00-FFEF'
+    unicodeRange: "U+0000-00FF, U+2000-206F, U+3000-303F, U+FF00-FFEF",
   },
   {
-    family: 'Noto Serif SC',
-    fileName: 'noto-serif-sc-400-cjk-common.woff2',
+    family: "Noto Serif SC",
+    fileName: "noto-serif-sc-400-cjk-common.woff2",
     weight: 400,
-    unicodeRange: 'U+4E00-9FFF'
+    unicodeRange: "U+4E00-9FFF",
   },
   {
-    family: 'Noto Serif SC',
-    fileName: 'noto-serif-sc-600-latin.woff2',
+    family: "Noto Serif SC",
+    fileName: "noto-serif-sc-600-latin.woff2",
     weight: 600,
-    unicodeRange: 'U+0000-00FF, U+2000-206F, U+3000-303F, U+FF00-FFEF'
+    unicodeRange: "U+0000-00FF, U+2000-206F, U+3000-303F, U+FF00-FFEF",
   },
   {
-    family: 'Noto Serif SC',
-    fileName: 'noto-serif-sc-600-cjk-common.woff2',
+    family: "Noto Serif SC",
+    fileName: "noto-serif-sc-600-cjk-common.woff2",
     weight: 600,
-    unicodeRange: 'U+4E00-9FFF'
-  }
+    unicodeRange: "U+4E00-9FFF",
+  },
 ] as const satisfies readonly HomeHeadCriticalFontFace[];
 
 const renderHomeHeadCriticalFontFace = ({
   family,
   fileName,
   weight,
-  unicodeRange
+  unicodeRange,
 }: HomeHeadCriticalFontFace): string => String.raw`@font-face {
   font-family: "${family}";
   src: url("${withBase(`/fonts/${fileName}`)}") format("woff2");
@@ -97,7 +113,9 @@ const renderHomeHeadCriticalFontFace = ({
 }`;
 
 const homeHeadCriticalCss = [
-  HOME_HEAD_CRITICAL_FONT_FACES.map(renderHomeHeadCriticalFontFace).join('\n\n'),
+  HOME_HEAD_CRITICAL_FONT_FACES.map(renderHomeHeadCriticalFontFace).join(
+    "\n\n",
+  ),
   String.raw`
 
 :root {
@@ -383,6 +401,12 @@ body[data-reading="immersive"] .reader-toggle .icon-book-open {
   gap: 16px;
 }
 
+.list-item__row .badge {
+  height: 24px;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
 .list-item__title {
   margin: 0;
   font-size: 18px;
@@ -612,8 +636,8 @@ body[data-reading="immersive"] .reader-toggle .icon-book-open {
       calc(36px + env(safe-area-inset-bottom)) calc(var(--pad-x) + env(safe-area-inset-left));
   }
 }
-`
-].join('\n\n');
+`,
+].join("\n\n");
 ---
 
 <BaseLayout bodyClass={homeBodyClass} deferGlobalStyles={true}>
@@ -636,8 +660,8 @@ body[data-reading="immersive"] .reader-toggle .icon-book-open {
             {introMore}
             {resolvedIntroMoreLinks.map((link, index) => (
               <>
-                {' '}
-                {index > 0 && <>或{' '}</>}
+                {" "}
+                {index > 0 && <>或 </>}
                 {index === resolvedIntroMoreLinks.length - 1 ? (
                   <span class="intro__link-tail">
                     <a href={withBase(link.href)}>{link.label}</a>
@@ -657,20 +681,22 @@ body[data-reading="immersive"] .reader-toggle .icon-book-open {
   <h2 class="section-title section-title--index">索引</h2>
 
   <div class="list">
-    {latest.map((entry) => {
-      const slug = getEssaySlug(entry);
-      const href = withBase(`/archive/${slug}/`);
-      const visibleTags = getVisibleArticleMetaTags(entry.data.tags, 'home');
-      return (
-        <EntryListItem
-          href={href}
-          title={entry.data.title}
-          date={entry.data.date}
-          visibleTags={visibleTags}
-          articleMetaSettings={articleMeta}
-          excerpt={getEssayDerivedText(entry).excerpt}
-        />
-      );
-    })}
+    {
+      latest.map((entry) => {
+        const slug = getEssaySlug(entry);
+        const href = withBase(`/archive/${slug}/`);
+        const visibleTags = getVisibleArticleMetaTags(entry.data.tags, "home");
+        return (
+          <EntryListItem
+            href={href}
+            title={entry.data.title}
+            date={entry.data.date}
+            visibleTags={visibleTags}
+            articleMetaSettings={articleMeta}
+            excerpt={getEssayDerivedText(entry).excerpt}
+          />
+        );
+      })
+    }
   </div>
 </BaseLayout>

--- a/src/styles/components/lists.css
+++ b/src/styles/components/lists.css
@@ -199,6 +199,10 @@
   gap: 16px;
 }
 
+.list-item__row .badge {
+  height: 24px;
+}
+
 .list-item__title {
   margin: 0;
   font-size: 18px;
@@ -232,6 +236,8 @@
 .badge {
   display: inline-flex;
   align-items: center;
+  flex-shrink: 0;
+  white-space: nowrap;
   padding: 0 7px;
   border: 1px solid var(--border);
   border-radius: 999px;
@@ -330,6 +336,10 @@
     flex-direction: column;
     align-items: flex-start;
     gap: 6px;
+  }
+
+  .list-item__row .badge {
+    height: 24px;
   }
 
   .list-item__meta {


### PR DESCRIPTION
调整了`.list-item__row .badge`的样式，为列表 badge 增加不收缩与禁止换行，避免标题过长时出现竖向拉伸/断行

| 当前 | 调整后 |
|-----|-----|
| <img width="1281" height="614" alt="0007b3ba-918e-4205-98bd-ec3a34f0a1ad" src="https://github.com/user-attachments/assets/60cc8423-6b53-4207-8186-03fd9401a961" /> | <img width="1513" height="588" alt="c84fc5c8-685a-48de-b0fb-7a6c79bc47c4" src="https://github.com/user-attachments/assets/84cf74d0-c13c-4754-baf9-09d2f7ef2b1b" /> |