### PR TITLE
feat: add system theme mode

### DIFF
--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -94,6 +94,7 @@ const showAdminEntry = settings.ui.sidebarActions.showAdminEntry && settings.sit
         aria-pressed="false"
         title="夜间模式"
       >
+        <UiIcon name="monitor" class="icon icon-system" />
         <UiIcon name="moon" class="icon icon-moon" />
         <UiIcon name="sun" class="icon icon-sun" />
       </button>

--- a/src/components/UiIcon.astro
+++ b/src/components/UiIcon.astro
@@ -14,6 +14,7 @@ import Link from '@lucide/astro/icons/link';
 import List from '@lucide/astro/icons/list';
 import MapPin from '@lucide/astro/icons/map-pin';
 import Moon from '@lucide/astro/icons/moon';
+import Monitor from '@lucide/astro/icons/monitor';
 import MonitorDot from '@lucide/astro/icons/monitor-dot';
 import PenLine from '@lucide/astro/icons/pen-line';
 import Pilcrow from '@lucide/astro/icons/pilcrow';
@@ -37,6 +38,7 @@ type UiIconName =
   | 'list'
   | 'map-pin'
   | 'moon'
+  | 'monitor'
   | 'monitor-dot'
   | 'paragraph'
   | 'pen'
@@ -77,6 +79,7 @@ const uiIconComponents = {
   list: List,
   'map-pin': MapPin,
   moon: Moon,
+  monitor: Monitor,
   'monitor-dot': MonitorDot,
   paragraph: Pilcrow,
   pen: PenLine,

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -54,12 +54,21 @@ const withBase = createWithBase(base);
   <head>
     <script is:inline>
       (() => {
-        const key = 'theme';
-        let stored = null;
-        try { stored = localStorage.getItem(key); } catch (_) {}
+        const themeKey = 'theme';
+        const modeKey = 'theme-mode';
+        let storedMode = null;
+        let legacyTheme = null;
+        try {
+          storedMode = localStorage.getItem(modeKey);
+          legacyTheme = localStorage.getItem(themeKey);
+        } catch (_) {}
         const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-        const theme = stored === 'dark' || stored === 'light' ? stored : (prefersDark ? 'dark' : 'light');
+        const mode = storedMode === 'system' || storedMode === 'dark' || storedMode === 'light'
+          ? storedMode
+          : (legacyTheme === 'dark' || legacyTheme === 'light' ? legacyTheme : 'system');
+        const theme = mode === 'system' ? (prefersDark ? 'dark' : 'light') : mode;
         document.documentElement.dataset.theme = theme;
+        document.documentElement.dataset.themeMode = mode;
       })();
     </script>
     <meta charset="utf-8" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -293,7 +293,8 @@ a {
   display: block;
 }
 
-.theme-toggle .icon-sun {
+.theme-toggle .icon-sun,
+.theme-toggle .icon-system {
   display: none;
 }
 
@@ -302,6 +303,15 @@ a {
 }
 
 :root[data-theme="dark"] .theme-toggle .icon-moon {
+  display: none;
+}
+
+:root[data-theme-mode="system"] .theme-toggle .icon-system {
+  display: block;
+}
+
+:root[data-theme-mode="system"] .theme-toggle .icon-moon,
+:root[data-theme-mode="system"] .theme-toggle .icon-sun {
   display: none;
 }
 

--- a/src/scripts/sidebar-theme.ts
+++ b/src/scripts/sidebar-theme.ts
@@ -1,4 +1,8 @@
-const KEY = 'theme';
+const THEME_KEY = 'theme';
+const THEME_MODE_KEY = 'theme-mode';
+type Theme = 'light' | 'dark';
+type ThemeMode = Theme | 'system';
+
 const root = document.documentElement;
 const body = document.body;
 
@@ -15,30 +19,93 @@ const isLongPage = () =>
   /^(?:\/(?:archive|essay|memo)(?:\/|$))/.test(window.location.pathname);
 
 let updateFloating = () => {};
+const colorSchemeMq = window.matchMedia('(prefers-color-scheme: dark)');
 
-const isDark = () => root.dataset.theme === 'dark';
+const isTheme = (value: string | null): value is Theme =>
+  value === 'light' || value === 'dark';
 
-const applyTheme = (theme: string) => {
+const isThemeMode = (value: string | null): value is ThemeMode =>
+  value === 'system' || isTheme(value);
+
+const getSystemTheme = (): Theme => colorSchemeMq.matches ? 'dark' : 'light';
+
+const resolveTheme = (mode: ThemeMode): Theme =>
+  mode === 'system' ? getSystemTheme() : mode;
+
+const readThemeMode = (): ThemeMode => {
+  try {
+    const storedMode = localStorage.getItem(THEME_MODE_KEY);
+    if (isThemeMode(storedMode)) return storedMode;
+
+    const legacyTheme = localStorage.getItem(THEME_KEY);
+    if (isTheme(legacyTheme)) return legacyTheme;
+  } catch (_) {}
+
+  return 'system';
+};
+
+const writeThemeMode = (mode: ThemeMode) => {
+  try {
+    localStorage.setItem(THEME_MODE_KEY, mode);
+    if (mode === 'system') {
+      localStorage.removeItem(THEME_KEY);
+    } else {
+      localStorage.setItem(THEME_KEY, mode);
+    }
+  } catch (_) {}
+};
+
+const getNextThemeMode = (mode: ThemeMode): ThemeMode => {
+  if (mode === 'system') return 'light';
+  if (mode === 'light') return 'dark';
+  return 'system';
+};
+
+const getThemeModeLabel = (mode: ThemeMode, theme: Theme): string => {
+  const current = theme === 'dark' ? '深色' : '浅色';
+  const nextMode = getNextThemeMode(mode);
+  const next = nextMode === 'system'
+    ? '跟随系统'
+    : (nextMode === 'dark' ? '深色模式' : '浅色模式');
+
+  if (mode === 'system') {
+    return `跟随系统（当前${current}模式），点击固定为${next}`;
+  }
+
+  return `${current}模式，点击切换为${next}`;
+};
+
+let activeThemeMode: ThemeMode = readThemeMode();
+
+const applyTheme = (theme: Theme, mode: ThemeMode = activeThemeMode) => {
   root.dataset.theme = theme;
+  root.dataset.themeMode = mode;
   const dark = theme === 'dark';
   if (themeBtn) {
-    themeBtn.setAttribute('aria-pressed', dark ? 'true' : 'false');
-    const label = dark ? '浅色模式' : '夜间模式';
+    themeBtn.setAttribute('aria-pressed', mode === 'system' ? 'mixed' : (dark ? 'true' : 'false'));
+    const label = getThemeModeLabel(mode, theme);
     themeBtn.setAttribute('aria-label', label);
     themeBtn.setAttribute('title', label);
   }
 };
 
+const setThemeMode = (mode: ThemeMode, persist = true) => {
+  activeThemeMode = mode;
+  applyTheme(resolveTheme(mode), mode);
+  if (persist) writeThemeMode(mode);
+};
+
 const initTheme = () => {
-  const current = isDark() ? 'dark' : 'light';
-  applyTheme(current);
+  setThemeMode(activeThemeMode, false);
   themeBtn?.addEventListener('click', () => {
-    const next = isDark() ? 'light' : 'dark';
-    applyTheme(next);
-    try {
-      localStorage.setItem(KEY, next);
-    } catch (_) {}
+    setThemeMode(getNextThemeMode(activeThemeMode));
   });
+
+  const syncSystemTheme = () => {
+    if (activeThemeMode === 'system') setThemeMode('system', false);
+  };
+
+  colorSchemeMq.addEventListener?.('change', syncSystemTheme);
 };
 
 const isReaderOn = () => body?.dataset.reading === 'immersive';

--- a/src/styles/components/layout.css
+++ b/src/styles/components/layout.css
@@ -625,7 +625,8 @@
   transition: transform 0.25s ease;
 }
 
-.theme-toggle .icon-sun {
+.theme-toggle .icon-sun,
+.theme-toggle .icon-system {
   display: none;
 }
 
@@ -634,6 +635,15 @@
 }
 
 :root[data-theme="dark"] .theme-toggle .icon-moon {
+  display: none;
+}
+
+:root[data-theme-mode="system"] .theme-toggle .icon-system {
+  display: block;
+}
+
+:root[data-theme-mode="system"] .theme-toggle .icon-moon,
+:root[data-theme-mode="system"] .theme-toggle .icon-sun {
   display: none;
 }
 


### PR DESCRIPTION
## Summary
- add a system theme mode that follows `prefers-color-scheme`
- persist explicit light/dark choices while keeping system mode responsive to OS changes
- show a monitor icon for system mode, with moon/sun for manual modes

## Verification
- `npm run check`