### PR TITLE
feat: 支持可选文章更新时间

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -244,6 +244,7 @@ draft: false        # Draft: hidden from list/RSS in production (visible in loca
 archive: true       # Archive switch: false excludes it from /archive and /archive/rss.xml (default true; detail page and /essay remain available)
 slug: optional      # Custom URL slug (defaults to the flattened content path, e.g. 2024/my-post -> 2024-my-post)
 badge: optional     # List badge; if omitted, list shows "Essay"
+updatedAt: 2026-01-02 # Optional update date; hidden when omitted
 ```
 
 `essay.date` should use the `YYYY-MM-DD` format for archive grouping, ordering, and page date display.
@@ -257,6 +258,14 @@ publishedAt: 2026-01-01T12:00:00+08:00
 ```
 
 `publishedAt` does not need to be added to existing content in bulk. Public lists, archives, RSS, and page date display still use `date`.
+
+If you need to show an article revision date, you can add the optional field:
+
+```yaml
+updatedAt: 2026-01-02
+```
+
+`updatedAt` accepts `YYYY-MM-DD` or an ISO 8601 datetime and is displayed as an update date in the article meta line. When omitted, pages keep the current behavior and no update date is shown.
 
 Unquoted YAML datetimes are also accepted. In rare UTC-boundary cases, the parser may have already lost the original timezone text; in that case the parsed UTC date is used.
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ draft: false        # 草稿：上线后不会出现在列表/RSS（本地预览
 archive: true       # 归档开关：false 不进 /archive 与 /archive/rss.xml（默认 true，详情与 /essay 仍可见，可省略）
 slug: optional      # 自定义 URL slug（默认使用拍平后的内容路径，例如 2024/my-post → 2024-my-post）
 badge: optional     # 列表徽标；未填时列表显示“随笔”
+updatedAt: 2026-01-02 # 可选更新时间；未填写时不会显示
 ```
 
 `essay.date` 建议使用 `YYYY-MM-DD` 格式，用于归档、排序和页面日期展示。
@@ -256,6 +257,14 @@ publishedAt: 2026-01-01T12:00:00+08:00
 ```
 
 `publishedAt` 无需为旧内容批量补充。当前公开列表、归档、RSS 和页面日期仍以 `date` 为准。
+
+如需展示文章修订日期，可以额外填写可选字段：
+
+```yaml
+updatedAt: 2026-01-02
+```
+
+`updatedAt` 支持 `YYYY-MM-DD` 或 ISO 8601 datetime，展示时按日期显示为“更新于：YYYY-MM-DD”。未填写时页面保持原样，不会显示更新时间。
 
 未加引号的 YAML datetime 也会继续兼容读取。少数跨 UTC 日期边界的场景下，解析器可能已丢失原始时区文本，此时会按解析后的 UTC 日期处理。
 

--- a/src/components/EntryListItem.astro
+++ b/src/components/EntryListItem.astro
@@ -7,6 +7,7 @@ const {
   title,
   excerpt,
   date,
+  updatedAt = null,
   visibleTags = [],
   articleMetaSettings
 } = Astro.props as {
@@ -14,6 +15,7 @@ const {
   title: string;
   excerpt?: string | null;
   date: Date;
+  updatedAt?: Date | null;
   visibleTags?: string[];
   articleMetaSettings: ArticleMetaSettings;
 };
@@ -30,7 +32,14 @@ const shouldShowMetaLine = articleMetaSettings.showDate || (articleMetaSettings.
     <div class="meta-line meta-line--items">
       {articleMetaSettings.showDate ? (
         <span class="meta-line__item">
-          {articleMetaSettings.dateLabel ? `${articleMetaSettings.dateLabel}` : ''}{formatISODateUtc(date)}
+          <time datetime={date.toISOString()}>
+            {`${articleMetaSettings.dateLabel ?? ''}${formatISODateUtc(date)}`}
+          </time>
+        </span>
+      ) : null}
+      {articleMetaSettings.showDate && updatedAt ? (
+        <span class="meta-line__item">
+          <time datetime={updatedAt.toISOString()}>{`更新于：${formatISODateUtc(updatedAt)}`}</time>
         </span>
       ) : null}
       {articleMetaSettings.showTags && visibleTags.length ? (

--- a/src/components/EssayCard.astro
+++ b/src/components/EssayCard.astro
@@ -7,6 +7,7 @@ const {
   title,
   excerpt,
   date,
+  updatedAt = null,
   visibleTags = [],
   badge = '随笔',
   slug = '',
@@ -16,6 +17,7 @@ const {
   title: string;
   excerpt?: string | null;
   date: Date;
+  updatedAt?: Date | null;
   visibleTags?: string[];
   badge?: string;
   slug?: string;
@@ -42,7 +44,14 @@ const shouldShowMetaLine = articleMetaSettings.showDate || (articleMetaSettings.
     <div class="meta-line meta-line--items">
       {articleMetaSettings.showDate ? (
         <span class="meta-line__item">
-          {articleMetaSettings.dateLabel ? `${articleMetaSettings.dateLabel}` : ''}{formatISODateUtc(date)}
+          <time datetime={date.toISOString()}>
+            {`${articleMetaSettings.dateLabel ?? ''}${formatISODateUtc(date)}`}
+          </time>
+        </span>
+      ) : null}
+      {articleMetaSettings.showDate && updatedAt ? (
+        <span class="meta-line__item">
+          <time datetime={updatedAt.toISOString()}>{`更新于：${formatISODateUtc(updatedAt)}`}</time>
         </span>
       ) : null}
       {articleMetaSettings.showTags && visibleTags.length ? (

--- a/src/components/EssayPageView.astro
+++ b/src/components/EssayPageView.astro
@@ -74,6 +74,7 @@ const fallbackListId = 'essay-tag-list';
         title={entry.data.title}
         excerpt={getEssayDerivedText(entry).excerpt}
         date={entry.data.date}
+        updatedAt={entry.data.updatedAt}
         visibleTags={getVisibleArticleMetaTags(entry.data.tags, 'list')}
         articleMetaSettings={articleMeta}
         badge={entry.data.badge}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -17,6 +17,7 @@ const essayBaseFields = {
   draft: z.boolean().default(false),
   archive: z.boolean().default(true),
   publishedAt: z.unknown().optional(),
+  updatedAt: z.unknown().optional(),
   // Optional custom permalink. If present, it overrides the default public slug
   // derived from the entry id / path.
   slug: slugRule.optional()
@@ -56,13 +57,41 @@ const essaySchema = z.object(essayShape).transform((data, ctx) => {
     return z.NEVER;
   }
 
-  const normalizedData = { ...data };
-  delete normalizedData.publishedAt;
+  const hasExplicitUpdatedAt =
+    data.updatedAt != null &&
+    !(typeof data.updatedAt === 'string' && data.updatedAt.trim() === '');
+  const updatedAtInput = data.updatedAt;
+  const updatedAtResult = hasExplicitUpdatedAt ? parseEssayDateInput(updatedAtInput) : null;
+
+  if (hasExplicitUpdatedAt && !updatedAtResult) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['updatedAt'],
+      message: 'updatedAt must be a valid YYYY-MM-DD date or ISO 8601 datetime'
+    });
+    return z.NEVER;
+  }
+
+  if (updatedAtResult && updatedAtResult.date.valueOf() < dateResult.date.valueOf()) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['updatedAt'],
+      message: 'updatedAt must not be earlier than date'
+    });
+    return z.NEVER;
+  }
+
+  const {
+    publishedAt: _publishedAt,
+    updatedAt: _updatedAt,
+    ...normalizedData
+  } = data;
 
   return {
     ...normalizedData,
     date: dateResult.date,
-    ...(publishedAt ? { publishedAt } : {})
+    ...(publishedAt ? { publishedAt } : {}),
+    ...(updatedAtResult ? { updatedAt: updatedAtResult.date } : {})
   };
 });
 

--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -35,6 +35,7 @@ const derivedText = getEssayDerivedText(entry);
 const rawDescription = entry?.data?.description?.trim?.() ?? '';
 const description = rawDescription || truncateText(derivedText.excerpt, 90);
 const activeNavId: SidebarNavId = entry?.data?.archive === false ? 'essay' : 'archive';
+const updatedAt = entry.data.updatedAt ?? null;
 const articleReadingStats = articleMetaSettings.showWordCount || articleMetaSettings.showReadingTime
   ? (() => {
       const wordCount = derivedText.plainText.replace(/\s+/g, '').length;
@@ -62,6 +63,7 @@ const shouldShowMetaLine = articleMetaSettings.showDate
 >
   <Fragment slot="head">
     <meta property="article:published_time" content={entry.data.date.toISOString()} />
+    {updatedAt ? <meta property="article:modified_time" content={updatedAt.toISOString()} /> : null}
     {entryTags.map((tag: string) => (
       <meta property="article:tag" content={tag} />
     ))}
@@ -83,7 +85,14 @@ const shouldShowMetaLine = articleMetaSettings.showDate
       <div class="meta-line meta-line--items">
         {articleMetaSettings.showDate ? (
           <span class="meta-line__item">
-            {articleMetaSettings.dateLabel ? `${articleMetaSettings.dateLabel}` : ''}{formatISODateUtc(entry.data.date)}
+            <time datetime={entry.data.date.toISOString()}>
+              {`${articleMetaSettings.dateLabel ?? ''}${formatISODateUtc(entry.data.date)}`}
+            </time>
+          </span>
+        ) : null}
+        {articleMetaSettings.showDate && updatedAt ? (
+          <span class="meta-line__item">
+            <time datetime={updatedAt.toISOString()}>{`更新于：${formatISODateUtc(updatedAt)}`}</time>
           </span>
         ) : null}
         {articleMetaSettings.showTags && visibleTags.length ? (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -672,6 +672,7 @@ body[data-reading="immersive"] .reader-toggle .icon-book-open {
           href={href}
           title={entry.data.title}
           date={entry.data.date}
+          updatedAt={entry.data.updatedAt}
           visibleTags={visibleTags}
           articleMetaSettings={articleMeta}
           excerpt={getEssayDerivedText(entry).excerpt}


### PR DESCRIPTION
## 变更内容

- 新增 essay frontmatter 可选字段 `updatedAt`，支持 `YYYY-MM-DD` 或 ISO 8601 datetime。
- 当文章填写 `updatedAt` 时，在首页索引、随笔列表和文章详情页展示更新时间。
- 文章详情页同步输出 `article:modified_time`，便于 SEO/社交平台识别修订时间。
- 在 README / README.en 中补充字段说明。

## 兼容性说明

`updatedAt` 是完全可选的信息：

- 旧文章不需要批量补充该字段。
- 未填写 `updatedAt` 时，页面不会显示更新时间，现有展示保持不变。
- `date` 仍然负责归档、排序、RSS 发布时间和默认页面日期。
- 为避免误填，`updatedAt` 不能早于 `date`。

## 验证

- `npm run check`
- `npm run build`